### PR TITLE
dcopf

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,0 +1,19 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  status:
+    project:
+      default: false  # disable the default status that measures entire project
+      tests:
+        paths:
+          - "tests/"
+        target: 90%
+      source:
+        paths:
+          - "opf/"
+        target: 98%
+        threshold: 0.002
+    patch:
+      default:
+        target: 80%  # new contributions should hav

--- a/README.md
+++ b/README.md
@@ -21,13 +21,14 @@ pip install opf
 
 ## Formulations
 1. :o: AC-OPF (AC Optimal Power Flow): 
-    - The formulation can be found in [PGLib](https://github.com/power-grid-lib/pglib-opf).
+    - AC-OPF with a polar bus voltage variables.
+    - The detailed formulation can be found in [PGLib](https://github.com/power-grid-lib/pglib-opf).
     - **PyOPF** takes the the input files in PGLib, which is basically based on MATPOWER format.
     - Uses various solvers that are supported in Pyomo including IPOPT to solve the problem instance.
 
-2. :x:DC-OPF (DC Optimal Power Flow)
+2. :o:DC-OPF (DC Optimal Power Flow)
     - Linear approximation to AC-OPF.
-    - To be added
+    - Only use active power generations and bus voltage angles as variables.
 
 3. :x:SC-AC-OPF (Security Constrained AC Optimal Power Flow)
     -  To be added

--- a/data/pglib_opf_case14_ieee.m
+++ b/data/pglib_opf_case14_ieee.m
@@ -1,0 +1,214 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%                                                                  %%%%%
+%%%%    IEEE PES Power Grid Library - Optimal Power Flow - v21.07     %%%%%
+%%%%          (https://github.com/power-grid-lib/pglib-opf)           %%%%%
+%%%%               Benchmark Group - Typical Operations               %%%%%
+%%%%                         29 - July - 2021                         %%%%%
+%%%%                                                                  %%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+%   Power flow data for IEEE 14 bus test case.
+%   This data was converted from IEEE Common Data Format
+%   (ieee14cdf.txt) on 20-Sep-2004 by cdf2matp, rev. 1.11
+%
+%   Converted from IEEE CDF file from:
+%        http://www.ee.washington.edu/research/pstca/
+%
+%   Copyright (c) 1999 by Richard D. Christie, University of Washington
+%   Electrical Engineering Licensed under the Creative Commons Attribution 4.0
+%   International license, http://creativecommons.org/licenses/by/4.0/
+%
+%   CDF Header:
+%   08/19/93 UW ARCHIVE           100.0  1962 W IEEE 14 Bus Test Case
+%
+function mpc = pglib_opf_case14_ieee
+mpc.version = '2';
+mpc.baseMVA = 100.0;
+
+%% bus data
+%	bus_i	type	Pd	Qd	Gs	Bs	area	Vm	Va	baseKV	zone	Vmax	Vmin
+mpc.bus = [
+	1	 3	 0.0	 0.0	 0.0	 0.0	 1	    1.00000	    0.00000	 1.0	 1	    1.06000	    0.94000;
+	2	 2	 21.7	 12.7	 0.0	 0.0	 1	    1.00000	    0.00000	 1.0	 1	    1.06000	    0.94000;
+	3	 2	 94.2	 19.0	 0.0	 0.0	 1	    1.00000	    0.00000	 1.0	 1	    1.06000	    0.94000;
+	4	 1	 47.8	 -3.9	 0.0	 0.0	 1	    1.00000	    0.00000	 1.0	 1	    1.06000	    0.94000;
+	5	 1	 7.6	 1.6	 0.0	 0.0	 1	    1.00000	    0.00000	 1.0	 1	    1.06000	    0.94000;
+	6	 2	 11.2	 7.5	 0.0	 0.0	 1	    1.00000	    0.00000	 1.0	 1	    1.06000	    0.94000;
+	7	 1	 0.0	 0.0	 0.0	 0.0	 1	    1.00000	    0.00000	 1.0	 1	    1.06000	    0.94000;
+	8	 2	 0.0	 0.0	 0.0	 0.0	 1	    1.00000	    0.00000	 1.0	 1	    1.06000	    0.94000;
+	9	 1	 29.5	 16.6	 0.0	 19.0	 1	    1.00000	    0.00000	 1.0	 1	    1.06000	    0.94000;
+	10	 1	 9.0	 5.8	 0.0	 0.0	 1	    1.00000	    0.00000	 1.0	 1	    1.06000	    0.94000;
+	11	 1	 3.5	 1.8	 0.0	 0.0	 1	    1.00000	    0.00000	 1.0	 1	    1.06000	    0.94000;
+	12	 1	 6.1	 1.6	 0.0	 0.0	 1	    1.00000	    0.00000	 1.0	 1	    1.06000	    0.94000;
+	13	 1	 13.5	 5.8	 0.0	 0.0	 1	    1.00000	    0.00000	 1.0	 1	    1.06000	    0.94000;
+	14	 1	 14.9	 5.0	 0.0	 0.0	 1	    1.00000	    0.00000	 1.0	 1	    1.06000	    0.94000;
+];
+
+%% generator data
+%	bus	Pg	Qg	Qmax	Qmin	Vg	mBase	status	Pmax	Pmin
+mpc.gen = [
+	1	 170.0	 5.0	 10.0	 0.0	 1.0	 100.0	 1	 340	 0.0; % NG
+	2	 29.5	 0.0	 30.0	 -30.0	 1.0	 100.0	 1	 59	 0.0; % NG
+	3	 0.0	 20.0	 40.0	 0.0	 1.0	 100.0	 1	 0	 0.0; % SYNC
+	6	 0.0	 9.0	 24.0	 -6.0	 1.0	 100.0	 1	 0	 0.0; % SYNC
+	8	 0.0	 9.0	 24.0	 -6.0	 1.0	 100.0	 1	 0	 0.0; % SYNC
+];
+
+%% generator cost data
+%	2	startup	shutdown	n	c(n-1)	...	c0
+mpc.gencost = [
+	2	 0.0	 0.0	 3	   0.000000	   7.920951	   0.000000; % NG
+	2	 0.0	 0.0	 3	   0.000000	  23.269494	   0.000000; % NG
+	2	 0.0	 0.0	 3	   0.000000	   0.000000	   0.000000; % SYNC
+	2	 0.0	 0.0	 3	   0.000000	   0.000000	   0.000000; % SYNC
+	2	 0.0	 0.0	 3	   0.000000	   0.000000	   0.000000; % SYNC
+];
+
+%% branch data
+%	fbus	tbus	r	x	b	rateA	rateB	rateC	ratio	angle	status	angmin	angmax
+mpc.branch = [
+	1	 2	 0.01938	 0.05917	 0.0528	 472	 472	 472	 0.0	 0.0	 1	 -30.0	 30.0;
+	1	 5	 0.05403	 0.22304	 0.0492	 128	 128	 128	 0.0	 0.0	 1	 -30.0	 30.0;
+	2	 3	 0.04699	 0.19797	 0.0438	 145	 145	 145	 0.0	 0.0	 1	 -30.0	 30.0;
+	2	 4	 0.05811	 0.17632	 0.034	 158	 158	 158	 0.0	 0.0	 1	 -30.0	 30.0;
+	2	 5	 0.05695	 0.17388	 0.0346	 161	 161	 161	 0.0	 0.0	 1	 -30.0	 30.0;
+	3	 4	 0.06701	 0.17103	 0.0128	 160	 160	 160	 0.0	 0.0	 1	 -30.0	 30.0;
+	4	 5	 0.01335	 0.04211	 0.0	 664	 664	 664	 0.0	 0.0	 1	 -30.0	 30.0;
+	4	 7	 0.0	 0.20912	 0.0	 141	 141	 141	 0.978	 0.0	 1	 -30.0	 30.0;
+	4	 9	 0.0	 0.55618	 0.0	 53	 53	 53	 0.969	 0.0	 1	 -30.0	 30.0;
+	5	 6	 0.0	 0.25202	 0.0	 117	 117	 117	 0.932	 0.0	 1	 -30.0	 30.0;
+	6	 11	 0.09498	 0.1989	 0.0	 134	 134	 134	 0.0	 0.0	 1	 -30.0	 30.0;
+	6	 12	 0.12291	 0.25581	 0.0	 104	 104	 104	 0.0	 0.0	 1	 -30.0	 30.0;
+	6	 13	 0.06615	 0.13027	 0.0	 201	 201	 201	 0.0	 0.0	 1	 -30.0	 30.0;
+	7	 8	 0.0	 0.17615	 0.0	 167	 167	 167	 0.0	 0.0	 1	 -30.0	 30.0;
+	7	 9	 0.0	 0.11001	 0.0	 267	 267	 267	 0.0	 0.0	 1	 -30.0	 30.0;
+	9	 10	 0.03181	 0.0845	 0.0	 325	 325	 325	 0.0	 0.0	 1	 -30.0	 30.0;
+	9	 14	 0.12711	 0.27038	 0.0	 99	 99	 99	 0.0	 0.0	 1	 -30.0	 30.0;
+	10	 11	 0.08205	 0.19207	 0.0	 141	 141	 141	 0.0	 0.0	 1	 -30.0	 30.0;
+	12	 13	 0.22092	 0.19988	 0.0	 99	 99	 99	 0.0	 0.0	 1	 -30.0	 30.0;
+	13	 14	 0.17093	 0.34802	 0.0	 76	 76	 76	 0.0	 0.0	 1	 -30.0	 30.0;
+];
+
+% INFO    : === Translation Options ===
+% INFO    : Phase Angle Bound:           30.0 (deg.)
+% INFO    : Line Capacity Model:         stat
+% INFO    : Gen Active Capacity Model:   stat
+% INFO    : Gen Reactive Capacity Model: am50ag
+% INFO    : Gen Active Cost Model:       stat
+% INFO    : Setting Flat Start
+% INFO    : Line Capacity PAB:           15.0 (deg.)
+% INFO    : 
+% INFO    : === Generator Classification Notes ===
+% INFO    : SYNC   3   -     0.00
+% INFO    : NG     2   -   100.00
+% INFO    : 
+% INFO    : === Generator Active Capacity Stat Model Notes ===
+% INFO    : Gen at bus 1 - NG	: Pg=232.4, Pmax=332.4 -> Pmax=340   samples: 20
+% INFO    : Gen at bus 2 - NG	: Pg=40.0, Pmax=140.0 -> Pmax=59   samples: 6
+% INFO    : Gen at bus 3 - SYNC	: Pg=0.0, Pmax=100.0 -> Pmax=0   samples: 0
+% INFO    : Gen at bus 6 - SYNC	: Pg=0.0, Pmax=100.0 -> Pmax=0   samples: 0
+% INFO    : Gen at bus 8 - SYNC	: Pg=0.0, Pmax=100.0 -> Pmax=0   samples: 0
+% INFO    : 
+% INFO    : === Generator Reactive Capacity Atmost Max 50 Percent Active Model Notes ===
+% INFO    : Gen at bus 2 - NG	: Pmax 59.0, Qmin -40.0, Qmax 50.0 -> Qmin -30.0, Qmax 30.0
+% INFO    : 
+% INFO    : === Generator Active Cost Stat Model Notes ===
+% INFO    : Updated Generator Cost: NG - 0.0 20.0 0.0430293 -> 0 7.92095063323 0
+% INFO    : Updated Generator Cost: NG - 0.0 20.0 0.25 -> 0 23.2694943686 0
+% INFO    : Updated Generator Cost: SYNC - 0.0 40.0 0.01 -> 0 0.0 0
+% INFO    : Updated Generator Cost: SYNC - 0.0 40.0 0.01 -> 0 0.0 0
+% INFO    : Updated Generator Cost: SYNC - 0.0 40.0 0.01 -> 0 0.0 0
+% INFO    : 
+% INFO    : === Generator Bounds Update Notes ===
+% INFO    : 
+% INFO    : === Base KV Replacement Notes ===
+% WARNING : Bus 1 : basekv changed 0.0 => 1.0
+% WARNING : Bus 2 : basekv changed 0.0 => 1.0
+% WARNING : Bus 3 : basekv changed 0.0 => 1.0
+% WARNING : Bus 4 : basekv changed 0.0 => 1.0
+% WARNING : Bus 5 : basekv changed 0.0 => 1.0
+% WARNING : Bus 6 : basekv changed 0.0 => 1.0
+% WARNING : Bus 7 : basekv changed 0.0 => 1.0
+% WARNING : Bus 8 : basekv changed 0.0 => 1.0
+% WARNING : Bus 9 : basekv changed 0.0 => 1.0
+% WARNING : Bus 10 : basekv changed 0.0 => 1.0
+% WARNING : Bus 11 : basekv changed 0.0 => 1.0
+% WARNING : Bus 12 : basekv changed 0.0 => 1.0
+% WARNING : Bus 13 : basekv changed 0.0 => 1.0
+% WARNING : Bus 14 : basekv changed 0.0 => 1.0
+% INFO    : 
+% INFO    : === Transformer Setting Replacement Notes ===
+% INFO    : 
+% INFO    : === Line Capacity Stat Model Notes ===
+% WARNING : Missing data for branch flow stat model on line 1-2 using max current model : from_basekv=1.0 to_basekv=1.0 r=0.01938 x=0.05917
+% INFO    : Updated Thermal Rating: on line 1-2 : Rate A, Rate B, Rate C , 9900.0, 0.0, 0.0 -> 472
+% WARNING : Missing data for branch flow stat model on line 1-5 using max current model : from_basekv=1.0 to_basekv=1.0 r=0.05403 x=0.22304
+% INFO    : Updated Thermal Rating: on line 1-5 : Rate A, Rate B, Rate C , 9900.0, 0.0, 0.0 -> 128
+% WARNING : Missing data for branch flow stat model on line 2-3 using max current model : from_basekv=1.0 to_basekv=1.0 r=0.04699 x=0.19797
+% INFO    : Updated Thermal Rating: on line 2-3 : Rate A, Rate B, Rate C , 9900.0, 0.0, 0.0 -> 145
+% WARNING : Missing data for branch flow stat model on line 2-4 using max current model : from_basekv=1.0 to_basekv=1.0 r=0.05811 x=0.17632
+% INFO    : Updated Thermal Rating: on line 2-4 : Rate A, Rate B, Rate C , 9900.0, 0.0, 0.0 -> 158
+% WARNING : Missing data for branch flow stat model on line 2-5 using max current model : from_basekv=1.0 to_basekv=1.0 r=0.05695 x=0.17388
+% INFO    : Updated Thermal Rating: on line 2-5 : Rate A, Rate B, Rate C , 9900.0, 0.0, 0.0 -> 161
+% WARNING : Missing data for branch flow stat model on line 3-4 using max current model : from_basekv=1.0 to_basekv=1.0 r=0.06701 x=0.17103
+% INFO    : Updated Thermal Rating: on line 3-4 : Rate A, Rate B, Rate C , 9900.0, 0.0, 0.0 -> 160
+% WARNING : Missing data for branch flow stat model on line 4-5 using max current model : from_basekv=1.0 to_basekv=1.0 r=0.01335 x=0.04211
+% INFO    : Updated Thermal Rating: on line 4-5 : Rate A, Rate B, Rate C , 9900.0, 0.0, 0.0 -> 664
+% WARNING : Missing data for branch flow stat model on line 4-7 using max current model : from_basekv=1.0 to_basekv=1.0 r=0.0 x=0.20912
+% INFO    : Updated Thermal Rating: on transformer 4-7 : Rate A, Rate B, Rate C , 9900.0, 0.0, 0.0 -> 141
+% WARNING : Missing data for branch flow stat model on line 4-9 using max current model : from_basekv=1.0 to_basekv=1.0 r=0.0 x=0.55618
+% INFO    : Updated Thermal Rating: on transformer 4-9 : Rate A, Rate B, Rate C , 9900.0, 0.0, 0.0 -> 53
+% WARNING : Missing data for branch flow stat model on line 5-6 using max current model : from_basekv=1.0 to_basekv=1.0 r=0.0 x=0.25202
+% INFO    : Updated Thermal Rating: on transformer 5-6 : Rate A, Rate B, Rate C , 9900.0, 0.0, 0.0 -> 117
+% WARNING : Missing data for branch flow stat model on line 6-11 using max current model : from_basekv=1.0 to_basekv=1.0 r=0.09498 x=0.1989
+% INFO    : Updated Thermal Rating: on line 6-11 : Rate A, Rate B, Rate C , 9900.0, 0.0, 0.0 -> 134
+% WARNING : Missing data for branch flow stat model on line 6-12 using max current model : from_basekv=1.0 to_basekv=1.0 r=0.12291 x=0.25581
+% INFO    : Updated Thermal Rating: on line 6-12 : Rate A, Rate B, Rate C , 9900.0, 0.0, 0.0 -> 104
+% WARNING : Missing data for branch flow stat model on line 6-13 using max current model : from_basekv=1.0 to_basekv=1.0 r=0.06615 x=0.13027
+% INFO    : Updated Thermal Rating: on line 6-13 : Rate A, Rate B, Rate C , 9900.0, 0.0, 0.0 -> 201
+% WARNING : Missing data for branch flow stat model on line 7-8 using max current model : from_basekv=1.0 to_basekv=1.0 r=0.0 x=0.17615
+% INFO    : Updated Thermal Rating: on line 7-8 : Rate A, Rate B, Rate C , 9900.0, 0.0, 0.0 -> 167
+% WARNING : Missing data for branch flow stat model on line 7-9 using max current model : from_basekv=1.0 to_basekv=1.0 r=0.0 x=0.11001
+% INFO    : Updated Thermal Rating: on line 7-9 : Rate A, Rate B, Rate C , 9900.0, 0.0, 0.0 -> 267
+% WARNING : Missing data for branch flow stat model on line 9-10 using max current model : from_basekv=1.0 to_basekv=1.0 r=0.03181 x=0.0845
+% INFO    : Updated Thermal Rating: on line 9-10 : Rate A, Rate B, Rate C , 9900.0, 0.0, 0.0 -> 325
+% WARNING : Missing data for branch flow stat model on line 9-14 using max current model : from_basekv=1.0 to_basekv=1.0 r=0.12711 x=0.27038
+% INFO    : Updated Thermal Rating: on line 9-14 : Rate A, Rate B, Rate C , 9900.0, 0.0, 0.0 -> 99
+% WARNING : Missing data for branch flow stat model on line 10-11 using max current model : from_basekv=1.0 to_basekv=1.0 r=0.08205 x=0.19207
+% INFO    : Updated Thermal Rating: on line 10-11 : Rate A, Rate B, Rate C , 9900.0, 0.0, 0.0 -> 141
+% WARNING : Missing data for branch flow stat model on line 12-13 using max current model : from_basekv=1.0 to_basekv=1.0 r=0.22092 x=0.19988
+% INFO    : Updated Thermal Rating: on line 12-13 : Rate A, Rate B, Rate C , 9900.0, 0.0, 0.0 -> 99
+% WARNING : Missing data for branch flow stat model on line 13-14 using max current model : from_basekv=1.0 to_basekv=1.0 r=0.17093 x=0.34802
+% INFO    : Updated Thermal Rating: on line 13-14 : Rate A, Rate B, Rate C , 9900.0, 0.0, 0.0 -> 76
+% INFO    : 
+% INFO    : === Line Capacity Monotonicity Notes ===
+% INFO    : 
+% INFO    : === Voltage Setpoint Replacement Notes ===
+% INFO    : Bus 1	: V=1.06, theta=0.0 -> V=1.0, theta=0.0
+% INFO    : Bus 2	: V=1.045, theta=-4.98 -> V=1.0, theta=0.0
+% INFO    : Bus 3	: V=1.01, theta=-12.72 -> V=1.0, theta=0.0
+% INFO    : Bus 4	: V=1.019, theta=-10.33 -> V=1.0, theta=0.0
+% INFO    : Bus 5	: V=1.02, theta=-8.78 -> V=1.0, theta=0.0
+% INFO    : Bus 6	: V=1.07, theta=-14.22 -> V=1.0, theta=0.0
+% INFO    : Bus 7	: V=1.062, theta=-13.37 -> V=1.0, theta=0.0
+% INFO    : Bus 8	: V=1.09, theta=-13.36 -> V=1.0, theta=0.0
+% INFO    : Bus 9	: V=1.056, theta=-14.94 -> V=1.0, theta=0.0
+% INFO    : Bus 10	: V=1.051, theta=-15.1 -> V=1.0, theta=0.0
+% INFO    : Bus 11	: V=1.057, theta=-14.79 -> V=1.0, theta=0.0
+% INFO    : Bus 12	: V=1.055, theta=-15.07 -> V=1.0, theta=0.0
+% INFO    : Bus 13	: V=1.05, theta=-15.16 -> V=1.0, theta=0.0
+% INFO    : Bus 14	: V=1.036, theta=-16.04 -> V=1.0, theta=0.0
+% INFO    : 
+% INFO    : === Generator Setpoint Replacement Notes ===
+% INFO    : Gen at bus 1	: Pg=232.4, Qg=-16.9 -> Pg=170.0, Qg=5.0
+% INFO    : Gen at bus 1	: Vg=1.06 -> Vg=1.0
+% INFO    : Gen at bus 2	: Pg=40.0, Qg=42.4 -> Pg=29.5, Qg=0.0
+% INFO    : Gen at bus 2	: Vg=1.045 -> Vg=1.0
+% INFO    : Gen at bus 3	: Pg=0.0, Qg=23.4 -> Pg=0.0, Qg=20.0
+% INFO    : Gen at bus 3	: Vg=1.01 -> Vg=1.0
+% INFO    : Gen at bus 6	: Pg=0.0, Qg=12.2 -> Pg=0.0, Qg=9.0
+% INFO    : Gen at bus 6	: Vg=1.07 -> Vg=1.0
+% INFO    : Gen at bus 8	: Pg=0.0, Qg=17.4 -> Pg=0.0, Qg=9.0
+% INFO    : Gen at bus 8	: Vg=1.09 -> Vg=1.0
+% INFO    : 
+% INFO    : === Writing Matpower Case File Notes ===

--- a/opf/__init__.py
+++ b/opf/__init__.py
@@ -1,2 +1,5 @@
 from .io import parse_file, export_network
 from .core import build_model
+
+__name__ = "pyopf"
+__version__ = "0.2.0"

--- a/opf/core/acopf.py
+++ b/opf/core/acopf.py
@@ -8,14 +8,14 @@ from .acopf_exp import *
 
 
 class AbstractACOPFModel(AbstractPowerBaseModel):
-    """ Abstract optimization model class.  
+    """ Abstract AC-OPF optimization model class.  
     """
     def __init__(self, model_type):
         super().__init__(model_type)
 
     def _build_model(self) -> None:
         """ Define the (abstract) AC-OPF optimization model. 
-            This is enabled without having the specific parameter value.
+            This is enabled without having the specific parameter values.
         """
         print('build model...', end=' ')
         
@@ -142,6 +142,7 @@ class AbstractACOPFModel(AbstractPowerBaseModel):
 
         print('end')
 
+
     def instantiate_model(self, network:Dict[str,Any], init_var:Dict[str,Any] = None) -> pyo.ConcreteModel:
         print('instantiate model...', end=' ')
         
@@ -170,7 +171,7 @@ class AbstractACOPFModel(AbstractPowerBaseModel):
 
         # Generator
         pgmax, pgmin, qgmax, qgmin = {}, {}, {}, {}
-        pg_init, qg_init = {}, {}
+        pg, qg = {}, {}
         cost = {}
         for gen_idx in genidxs:
             gen = gens[gen_idx]
@@ -178,8 +179,8 @@ class AbstractACOPFModel(AbstractPowerBaseModel):
             pgmin[gen_idx] = gen['pmin']
             qgmax[gen_idx] = gen['qmax']
             qgmin[gen_idx] = gen['qmin']
-            pg_init[gen_idx] = gen['pg']
-            qg_init[gen_idx] = gen['qg']
+            pg[gen_idx] = gen['pg']
+            qg[gen_idx] = gen['qg']
             cost_raw = gen['cost']
             for i in range(ncost):
                 cost[(gen_idx,i)] = cost_raw[i]
@@ -252,6 +253,8 @@ class AbstractACOPFModel(AbstractPowerBaseModel):
             qf_from_init = init_var['qf1']
             qf_to_init = init_var['qf2']
         else:
+            pg_init = pg
+            qg_init = qg
             vm_init = { idx: 1. for idx in busidxs }
             va_init = { idx: 0. for idx in busidxs }
             pf_from_init = { idx: 0. for idx in branchidxs }

--- a/opf/core/acopf_exp.py
+++ b/opf/core/acopf_exp.py
@@ -1,4 +1,5 @@
 import pyomo.environ as pyo
+from pyomo.core.util import quicksum
 
 def cnst_pg_bound_min_exp(m, g):
     return m.pgmin[g] - m.pg[g] <= 0. 
@@ -74,19 +75,19 @@ def define_sets_balance_exp(m):
                 m.shunt_per_bus[busidx].add(shuntidx)
 
 def cnst_p_balance_exp(m, b):
-    return sum(m.pg[g] for g in m.gen_per_bus[b])\
-            - sum(m.pf_to[e] for e in m.branch_in_per_bus[b])\
-            - sum(m.pd[l] for l in m.load_per_bus[b])\
-            - sum(m.pf_from[e] for e in m.branch_out_per_bus[b])\
-            - sum(m.gs[s] for s in m.shunt_per_bus[b]) * m.vm[b]**2 \
+    return quicksum(m.pg[g] for g in m.gen_per_bus[b])\
+            - quicksum(m.pf_to[e] for e in m.branch_in_per_bus[b])\
+            - quicksum(m.pd[l] for l in m.load_per_bus[b])\
+            - quicksum(m.pf_from[e] for e in m.branch_out_per_bus[b])\
+            - quicksum(m.gs[s] for s in m.shunt_per_bus[b]) * m.vm[b]**2 \
             == 0.
 
 def cnst_q_balance_exp(m, b):
-    return sum(m.qg[g] for g in m.gen_per_bus[b])\
-            - sum(m.qf_to[e] for e in m.branch_in_per_bus[b])\
-            - sum(m.qd[l] for l in m.load_per_bus[b])\
-            - sum(m.qf_from[e] for e in m.branch_out_per_bus[b])\
-            + sum(m.bs[s] for s in m.shunt_per_bus[b]) * m.vm[b]**2\
+    return quicksum(m.qg[g] for g in m.gen_per_bus[b])\
+            - quicksum(m.qf_to[e] for e in m.branch_in_per_bus[b])\
+            - quicksum(m.qd[l] for l in m.load_per_bus[b])\
+            - quicksum(m.qf_from[e] for e in m.branch_out_per_bus[b])\
+            + quicksum(m.bs[s] for s in m.shunt_per_bus[b]) * m.vm[b]**2\
             == 0.
             
 def cnst_dva_lower_exp(m, e):
@@ -96,4 +97,4 @@ def cnst_dva_upper_exp(m, e):
     return m.va[m.bus_from[e]] - m.va[m.bus_to[e]] - m.dvamax[e] <= 0.
 
 def obj_cost_exp(m, g):
-    return sum(m.pg[g]*m.pg[g]*m.cost[g,0] + m.pg[g]*m.cost[g,1] + m.cost[g,2] for g in m.G)
+    return quicksum(m.pg[g]*m.pg[g]*m.cost[g,0] + m.pg[g]*m.cost[g,1] + m.cost[g,2] for g in m.G)

--- a/opf/core/dcopf.py
+++ b/opf/core/dcopf.py
@@ -1,0 +1,200 @@
+from typing import Any, Dict
+import pyomo.environ as pyo
+import numpy as np
+import math
+
+from .base import AbstractPowerBaseModel
+from .dcopf_exp import *
+
+
+class AbstractDCOPFModel(AbstractPowerBaseModel):
+    """ Abstract DC-OPF optimization model class.  
+    """
+    def __init__(self, model_type):
+        super().__init__(model_type)
+
+    def _build_model(self) -> None:
+        """ Define the (abstract) DC-OPF optimization model. 
+            This is enabled without having the specific parameter values.
+        """
+        print('build model...', end=' ')
+        self.model.B = pyo.Set() # bus indices
+        self.model.G = pyo.Set() # generator indices
+        self.model.E = pyo.Set() # branch indices
+        self.model.L = pyo.Set() # load indices
+        self.model.slack = pyo.Set() # the slack buses
+        self.model.ncost = pyo.Set() # the number of costs
+
+        self.model.gen_per_bus = pyo.Set(self.model.B, within=self.model.G)
+        self.model.load_per_bus = pyo.Set(self.model.B, within=self.model.L)
+        self.model.branch_in_per_bus = pyo.Set(self.model.B, within=self.model.E)
+        self.model.branch_out_per_bus = pyo.Set(self.model.B, within=self.model.E)
+
+        # # ====================
+        # # I.    Parameters
+        # # ====================
+        self.model.pg_init = pyo.Param(self.model.G, within=pyo.Reals, mutable=True)
+        self.model.va_init = pyo.Param(self.model.B, within=pyo.Reals, mutable=True)
+        self.model.pf_init = pyo.Param(self.model.E, within=pyo.Reals, mutable=True)
+
+        self.model.pgmin = pyo.Param(self.model.G, within=pyo.Reals, mutable=True)
+        self.model.pgmax = pyo.Param(self.model.G, within=pyo.Reals, mutable=True)
+        self.model.pd = pyo.Param(self.model.L, within=pyo.Reals, mutable=True)
+        self.model.rate_a = pyo.Param(self.model.E, within=pyo.NonNegativeReals, mutable=True)
+        self.model.ang2pf = pyo.Param(self.model.E, self.model.B, within=pyo.Reals, default=0., mutable=True) # branch susceptance
+
+        self.model.cost = pyo.Param(self.model.G, self.model.ncost, within=pyo.Reals, mutable=True)
+
+        # # ====================
+        # # II.    Variables
+        # # ====================
+        self.model.pg = pyo.Var(self.model.G, initialize=self.model.pg_init, within=pyo.Reals) # active generation (injection), continuous
+        self.model.va = pyo.Var(self.model.B, initialize=self.model.va_init, within=pyo.Reals) # voltage angle, continuous
+        self.model.pf = pyo.Var(self.model.E, initialize=self.model.pf_init, within=pyo.Reals) # active flow (at each branch)
+
+        # ====================
+        # III.   Constraints
+        # ====================
+
+        # ====================
+        # III.a     Bounds
+        # ====================
+        self.model.cnst_pg_bound_min = pyo.Constraint(self.model.G, rule=cnst_pg_bound_min_exp)
+        self.model.cnst_pg_bound_max = pyo.Constraint(self.model.G, rule=cnst_pg_bound_max_exp)
+        self.model.cnst_pf_bound_min = pyo.Constraint(self.model.E, rule=cnst_pf_bound_min_exp)
+        self.model.cnst_pf_bound_max = pyo.Constraint(self.model.E, rule=cnst_pf_bound_max_exp)
+
+        # ====================
+        # III.b Voltage Angle at Slack Bus
+        # ====================
+        self.model.cnst_slack_va = pyo.Constraint(self.model.slack, rule=cnst_slack_va_exp)
+
+        # ====================
+        # III.c Define Flow
+        # ====================
+        self.model.cnst_pf = pyo.Constraint(self.model.E, rule=cnst_pf_exp)
+
+        # ====================
+        # III.d Power Balance
+        # ====================
+        self.model.sets_balance = pyo.BuildAction(rule=define_sets_balance_exp)
+        self.model.cnst_power_bal = pyo.Constraint(self.model.B, rule=cnst_power_bal_exp)
+
+        # ====================
+        # IIII.   Objective
+        # ====================
+        self.model.obj_cost = pyo.Objective(sense=pyo.minimize, rule=obj_cost_exp)
+        print('end')
+
+
+    def instantiate_model(self, network:Dict[str,Any], init_var:Dict[str,Any] = None) -> pyo.ConcreteModel:
+        print('instantiate model...', end=' ')
+        gens = network['gen']
+        buses = network['bus']
+        branches = network['branch']
+        loads = network['load']
+
+        busidxs = sorted(list(buses.keys())) # sort this for consistency between the pyomo vector and the input matpower 
+        loadidxs = sorted(list(loads.keys()))
+
+        branchidxs_all = sorted(list(branches.keys()))
+        branchidxs = [branch_idx for branch_idx in branchidxs_all if branches[branch_idx]['br_status']>0] # factor out not working branches
+        genidxs_all = sorted(list(gens.keys())) 
+        genidxs = [gen_idx for gen_idx in genidxs_all if gens[gen_idx]['gen_status']>0] # factor out not working generators
+
+        ncost = 3 # all PGLib input files have three cost coefficients
+
+        gen_per_bus = { busidx: [] for busidx in busidxs }
+        load_per_bus = { busidx: [] for busidx in busidxs }
+        branch_in_per_bus = { busidx: [] for busidx in busidxs }
+        branch_out_per_bus = { busidx: [] for busidx in busidxs }
+
+        # Generator
+        pgmax, pgmin, pg, qg, cost = {}, {}, {}, {}, {}
+        for gen_idx in genidxs:
+            gen = gens[gen_idx]
+            pgmax[gen_idx] = gen['pmax']
+            pgmin[gen_idx] = gen['pmin']
+            pg[gen_idx] = gen['pg']
+            qg[gen_idx] = gen['qg']
+            cost_raw = gen['cost']
+            for i in range(ncost):
+                cost[(gen_idx,i)] = cost_raw[i]
+            gen_per_bus[gen['gen_bus']].append(gen_idx)
+
+        # Load 
+        pd = {}
+        for load_idx in loadidxs:
+            load = loads[load_idx]
+            pd[load_idx] = load['pd']
+            load_per_bus[load['load_bus']].append(load_idx)
+
+        # Bus
+        slack = []
+        for bus_idx in busidxs:
+            if buses[bus_idx]['bus_type'] == 3:
+                slack.append(bus_idx)
+
+        # Branch
+        rate_a, dvamin, dvamax = {}, {}, {}
+        ang2pf = {}
+        for branch_idx in branchidxs:
+            branch = branches[branch_idx]
+            rate_a_val = branch['rate_a']
+            if rate_a_val == 0.: rate_a_val + 1e12
+            rate_a[branch_idx] = rate_a_val
+            dvamin[branch_idx] = branch['angmin']
+            dvamax[branch_idx] = branch['angmax']
+            f_bus = branch['f_bus']
+            t_bus = branch['t_bus']
+            r = branch['br_r']
+            x = branch['br_x']
+            b = -x / (r**2 + x**2) # susceptance
+            ang2pf_f_val = ang2pf.get((branch_idx,f_bus), 0.)
+            ang2pf_f_val += b
+            ang2pf_t_val = ang2pf.get((branch_idx,t_bus), 0.)
+            ang2pf_t_val -= b
+            ang2pf[(branch_idx,f_bus)] = ang2pf_f_val
+            ang2pf[(branch_idx,t_bus)] = ang2pf_t_val
+            branch_out_per_bus[branch['f_bus']].append(branch_idx) # from buses
+            branch_in_per_bus[branch['t_bus']].append(branch_idx)
+        
+        if init_var is not None:
+            pg_init = init_var['pg']
+            va_init = init_var['va']
+            pf_init = init_var['pf']
+        else:
+            pg_init = pg
+            va_init = { idx: 0. for idx in busidxs }
+            pf_init = { idx: 0. for idx in branchidxs }
+
+
+        data = {
+            'G': {None: genidxs},
+            'B': {None: busidxs},
+            'E': {None: branchidxs},
+            'L': {None: loadidxs},
+            'slack': {None: slack},
+            'pg_init': pg_init,
+            'va_init': va_init,
+            'pf_init': pf_init,
+            'ncost': {None: np.arange(ncost)},
+            'pd': pd,
+            'pgmax': pgmax,
+            'pgmin': pgmin,
+            'cost': cost,
+            'rate_a': rate_a,
+            'ang2pf': ang2pf,
+            'dvamin': dvamin, 'dvamax': dvamax
+        }
+
+        self.model.gen_per_bus_raw = gen_per_bus
+        self.model.load_per_bus_raw = load_per_bus
+        self.model.branch_in_per_bus_raw = branch_in_per_bus
+        self.model.branch_out_per_bus_raw = branch_out_per_bus
+
+        instance = self.model.create_instance({None: data}) # create instance (ConcreteModel), 
+        print('end')
+        return instance
+
+

--- a/opf/core/dcopf_exp.py
+++ b/opf/core/dcopf_exp.py
@@ -1,0 +1,48 @@
+import pyomo.environ as pyo
+from pyomo.core.util import quicksum
+
+def cnst_pg_bound_min_exp(m, g):
+    return m.pgmin[g] - m.pg[g] <= 0. 
+
+def cnst_pg_bound_max_exp(m, g):
+    return m.pg[g] - m.pgmax[g] <= 0. 
+
+def cnst_pf_bound_min_exp(m, e):
+    return -m.rate_a[e] - m.pf[e] <= 0.
+
+def cnst_pf_bound_max_exp(m, e):
+    return m.pf[e] - m.rate_a[e] <= 0.
+
+def cnst_slack_va_exp(m, s):
+    return m.va[s] == 0.
+
+def cnst_pf_exp(m, e):
+    return m.pf[e] - quicksum(m.ang2pf[e,b]*m.va[b] for b in m.B) == 0.
+
+def define_sets_balance_exp(m):
+    for busidx, genlist in m.gen_per_bus_raw.items():
+        if len(genlist) > 0:
+            for genidx in genlist:
+                m.gen_per_bus[busidx].add(genidx)
+
+    for busidx, loadlist in m.load_per_bus_raw.items():
+        if len(loadlist) > 0:
+            for loadidx in loadlist:
+                m.load_per_bus[busidx].add(loadidx)
+
+    for busidx, branchlist in m.branch_in_per_bus_raw.items():
+        if len(branchlist) > 0:
+            for branchidx in branchlist:
+                m.branch_in_per_bus[busidx].add(branchidx)
+    
+    for busidx, branchlist in m.branch_out_per_bus_raw.items():
+        if len(branchlist) > 0:
+            for branchidx in branchlist:
+                m.branch_out_per_bus[busidx].add(branchidx)
+
+def cnst_power_bal_exp(m, b):
+    return quicksum(m.pf[e] for e in m.branch_out_per_bus[b]) - quicksum(m.pf[e] for e in m.branch_in_per_bus[b])\
+            - quicksum(m.pg[g] for g in m.gen_per_bus[b]) + quicksum(m.pd[l] for l in m.load_per_bus[b]) == 0.
+
+def obj_cost_exp(m, g):
+    return quicksum(m.pg[g]*m.pg[g]*m.cost[g,0] + m.pg[g]*m.cost[g,1] + m.cost[g,2] for g in m.G)

--- a/opf/core/func.py
+++ b/opf/core/func.py
@@ -1,4 +1,5 @@
 from .acopf import AbstractACOPFModel
+from .dcopf import AbstractDCOPFModel
 from .base import AbstractPowerBaseModel
 
 
@@ -14,8 +15,10 @@ def build_model(model_type:str) -> AbstractPowerBaseModel:
     
     if model_type == 'acopf':
         model = AbstractACOPFModel(model_type)
-        model._build_model()
+    elif model_type == 'dcopf':
+        model = AbstractDCOPFModel(model_type)
     else:
         assert False
 
+    model._build_model()
     return model

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,8 @@ from setuptools import setup, find_packages
 from codecs import open
 from os import path
 
+import opf
+
 # The directory containing this file
 HERE = path.abspath(path.dirname(__file__))
 
@@ -43,7 +45,7 @@ packages = [
 # This call to setup() does all the work
 setup(
     name="opf",
-    version="0.1.0",
+    version=opf.__version__,
     description="PyOPF: Optimal Power Flow Modeling in Python",
     long_description=load_description(),
     long_description_content_type="text/markdown",

--- a/tests/test_dcopf_solve.py
+++ b/tests/test_dcopf_solve.py
@@ -1,0 +1,56 @@
+import unittest
+import opf
+from pathlib import Path
+import pyomo.environ as pyo
+
+class DCOPFSolveTest_case5(unittest.TestCase):
+    def test_parse(self):
+        matpower_fn = Path("./data/pglib_opf_case5_pjm.m")
+        model = opf.build_model('dcopf')
+        self.assertEqual(model.model_type, 'dcopf')
+        network = opf.parse_file(matpower_fn)
+        instance = model.instantiate_model(network)
+        solver = pyo.SolverFactory("ipopt")
+        results = solver.solve(instance, tee=False)
+
+        self.assertEqual(results.solver.termination_condition, 'optimal')
+        
+        self.assertAlmostEqual(pyo.value(instance.obj_cost), 17479.896769813888)
+            
+        self.assertAlmostEqual(pyo.value(instance.pg[1]), 0.4000000096631537)
+        self.assertAlmostEqual(pyo.value(instance.pg[2]), 1.7000000164929279)
+        self.assertAlmostEqual(pyo.value(instance.pg[3]), 3.2349483673666066)
+        self.assertAlmostEqual(pyo.value(instance.pg[4]), 7.656316434159741e-09)
+        self.assertAlmostEqual(pyo.value(instance.pg[5]), 4.6650515988209955)
+
+        self.assertAlmostEqual(pyo.value(instance.va[1]), -0.05735150733969868)
+        self.assertAlmostEqual(pyo.value(instance.va[2]), 0.01352060911369567)
+        self.assertAlmostEqual(pyo.value(instance.va[3]), 0.008035714369804532)
+        self.assertAlmostEqual(pyo.value(instance.va[4]), 0.0)
+        self.assertAlmostEqual(pyo.value(instance.va[5]), -0.07199280071944555)
+
+
+class DCOPFSolveTest_case14(unittest.TestCase):
+    def test_parse(self):
+        matpower_fn = Path("./data/pglib_opf_case14_ieee.m")
+        model = opf.build_model('dcopf')
+        self.assertEqual(model.model_type, 'dcopf')
+        network = opf.parse_file(matpower_fn)
+        instance = model.instantiate_model(network)
+        solver = pyo.SolverFactory("ipopt")
+        results = solver.solve(instance, tee=False)
+
+        self.assertEqual(results.solver.termination_condition, 'optimal')
+        
+        self.assertAlmostEqual(pyo.value(instance.obj_cost), 2051.5262699779273)
+        self.assertAlmostEqual(pyo.value(instance.pg[1]), 2.5899999800011604)
+        self.assertAlmostEqual(pyo.value(instance.pg[2]), -9.962008701445461e-09)
+        self.assertAlmostEqual(pyo.value(instance.va[1]), 0.0)
+        self.assertAlmostEqual(pyo.value(instance.va[2]), 0.11768346281509813)
+        self.assertAlmostEqual(pyo.value(instance.pf[1]), 1.7962128752942261)
+        self.assertAlmostEqual(pyo.value(instance.pf[2]), 0.7937871047069344)
+
+        
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Add dcopf using basic formulation 
- Note that PTDF based formulation should be added here with the type of 'dcopf-ptdf' or something like it.
- Should test on all PGLib testcases. For now, it is tested on case5 and case14, which are also included in the directory `data`
- Consequently, this resolves #2 
- From now on, the development version is bumped to 0.2.0 
- Ref.: Velloso, Alexandre, Pascal Van Hentenryck, and Emma S. Johnson. "An exact and scalable problem decomposition for security-constrained optimal power flow." Electric Power Systems Research 195 (2021): 106677. [link](https://www.sciencedirect.com/science/article/pii/S0378779620304806)
