### PR TITLE
enable PTDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ pip install opf
 
 2. :o:DC-OPF (DC Optimal Power Flow)
     ```python
-    model = opf.build_model('dcopf') # base DC-OPF model
+    model = opf.build_model('dcopf')      # base DC-OPF model
     model = opf.build_model('dcopf-ptdf') # DC-OPF model using PTDF
     ```
     - Linear approximation to AC-OPF.

--- a/README.md
+++ b/README.md
@@ -34,19 +34,19 @@ pip install opf
 
 2. :o:DC-OPF (DC Optimal Power Flow)
     ```python
-    model = opf.build_model('dcopf') # base DCOPF model
+    model = opf.build_model('dcopf') # base DC-OPF model
+    model = opf.build_model('dcopf-ptdf') # DC-OPF model using PTDF
     ```
     - Linear approximation to AC-OPF.
     - Also support PTDF (power transfer distribution factor) based formulation.
-    - Only use active power generations and bus voltage angles as variables.
+    - Only use active power generations and bus voltage angles (for base DC-OPF) as variables.
+    - Like AC-OPF, PGLib m-files can be taken as input.
 
 3. :x:SC-DC-OPF (Security Constrained DC Optimal Power Flow)
     -  To be added
 
-
 4. :x:SC-AC-OPF (Security Constrained AC Optimal Power Flow)
     -  To be added
-
 
 ## Warmstarting
 * **PyOPF** supports primal and dual warmstarting. Documentation is to be added.

--- a/opf/__init__.py
+++ b/opf/__init__.py
@@ -1,5 +1,5 @@
 from .io import parse_file, export_network
-from .core import build_model, setup_warmstart
+from .core import build_model, setup_warmstart, compute_ptdf
 
 __name__ = "pyopf"
 __version__ = "0.2.0"

--- a/opf/core/__init__.py
+++ b/opf/core/__init__.py
@@ -1,2 +1,6 @@
 from .func import build_model
 from .warmstart import setup_warmstart
+
+from .utils import compute_ptdf
+
+

--- a/opf/core/acopf.py
+++ b/opf/core/acopf.py
@@ -17,7 +17,7 @@ class AbstractACOPFModel(AbstractPowerBaseModel):
         """ Define the (abstract) AC-OPF optimization model. 
             This is enabled without having the specific parameter values.
         """
-        print('build model...', end=' ')
+        print('build model...', end=' ', flush=True)
         
         self.model.B = pyo.Set() # bus indices
         self.model.G = pyo.Set() # generator indices
@@ -140,11 +140,11 @@ class AbstractACOPFModel(AbstractPowerBaseModel):
         # ====================
         self.model.obj_cost = pyo.Objective(sense=pyo.minimize, rule=obj_cost_exp)
 
-        print('end')
+        print('end', flush=True)
 
 
     def instantiate_model(self, network:Dict[str,Any], init_var:Dict[str,Any] = None, verbose:bool = False) -> pyo.ConcreteModel:
-        print('instantiate model...', end=' ')
+        print('instantiate model...', end=' ', flush=True)
         
         gens = network['gen']
         buses = network['bus']
@@ -303,13 +303,10 @@ class AbstractACOPFModel(AbstractPowerBaseModel):
         self.model.branch_out_per_bus_raw = branch_out_per_bus
         self.model.shunt_per_bus_raw = shunt_per_bus
         
-        import time
-        t0 = time.time()
         instance = self.model.create_instance({None: data}, report_timing=verbose) # create instance (ConcreteModel), 
-        print('elapsed time for create_instance', time.time()-t0)
         instance.dual = pyo.Suffix(direction=pyo.Suffix.IMPORT_EXPORT) # define the dual assess point
         # note that self.model is not duplicated because it is desired to be AbstractModel 
         # for taking different types of problem instances consistently.
 
-        print('end')
+        print('end', flush=True)
         return instance

--- a/opf/core/acopf.py
+++ b/opf/core/acopf.py
@@ -143,7 +143,7 @@ class AbstractACOPFModel(AbstractPowerBaseModel):
         print('end')
 
 
-    def instantiate_model(self, network:Dict[str,Any], init_var:Dict[str,Any] = None) -> pyo.ConcreteModel:
+    def instantiate_model(self, network:Dict[str,Any], init_var:Dict[str,Any] = None, verbose:bool = False) -> pyo.ConcreteModel:
         print('instantiate model...', end=' ')
         
         gens = network['gen']
@@ -152,96 +152,96 @@ class AbstractACOPFModel(AbstractPowerBaseModel):
         loads = network['load']
         shunts = network['shunt']
 
-        busidxs = sorted(list(buses.keys())) # sort this for consistency between the pyomo vector and the input matpower 
-        loadidxs = sorted(list(loads.keys()))
-        shuntidxs = sorted(list(shunts.keys()))
+        busids = sorted(list(buses.keys())) # sort this for consistency between the pyomo vector and the input matpower 
+        loadids = sorted(list(loads.keys()))
+        shuntids = sorted(list(shunts.keys()))
 
-        branchidxs_all = sorted(list(branches.keys()))
-        branchidxs = [branch_idx for branch_idx in branchidxs_all if branches[branch_idx]['br_status']>0] # factor out not working branches
-        genidxs_all = sorted(list(gens.keys())) 
-        genidxs = [gen_idx for gen_idx in genidxs_all if gens[gen_idx]['gen_status']>0] # factor out not working generators
+        branchids_all = sorted(list(branches.keys()))
+        branchids = [branch_id for branch_id in branchids_all if branches[branch_id]['br_status']>0] # factor out not working branches
+        genids_all = sorted(list(gens.keys())) 
+        genids = [gen_id for gen_id in genids_all if gens[gen_id]['gen_status']>0] # factor out not working generators
 
         ncost = 3 # all PGLib input files have three cost coefficients
         
-        gen_per_bus = { busidx: [] for busidx in busidxs }
-        load_per_bus = { busidx: [] for busidx in busidxs }
-        branch_in_per_bus = { busidx: [] for busidx in busidxs }
-        branch_out_per_bus = { busidx: [] for busidx in busidxs }
-        shunt_per_bus = { busidx: [] for busidx in busidxs }
+        gen_per_bus = { busid: [] for busid in busids }
+        load_per_bus = { busid: [] for busid in busids }
+        branch_in_per_bus = { busid: [] for busid in busids }
+        branch_out_per_bus = { busid: [] for busid in busids }
+        shunt_per_bus = { busid: [] for busid in busids }
 
         # Generator
         pgmax, pgmin, qgmax, qgmin = {}, {}, {}, {}
         pg, qg = {}, {}
         cost = {}
-        for gen_idx in genidxs:
-            gen = gens[gen_idx]
-            pgmax[gen_idx] = gen['pmax']
-            pgmin[gen_idx] = gen['pmin']
-            qgmax[gen_idx] = gen['qmax']
-            qgmin[gen_idx] = gen['qmin']
-            pg[gen_idx] = gen['pg']
-            qg[gen_idx] = gen['qg']
+        for gen_id in genids:
+            gen = gens[gen_id]
+            pgmax[gen_id] = gen['pmax']
+            pgmin[gen_id] = gen['pmin']
+            qgmax[gen_id] = gen['qmax']
+            qgmin[gen_id] = gen['qmin']
+            pg[gen_id] = gen['pg']
+            qg[gen_id] = gen['qg']
             cost_raw = gen['cost']
             for i in range(ncost):
-                cost[(gen_idx,i)] = cost_raw[i]
-            gen_per_bus[gen['gen_bus']].append(gen_idx)
+                cost[(gen_id,i)] = cost_raw[i]
+            gen_per_bus[gen['gen_bus']].append(gen_id)
         
         # Load
         pd, qd = {}, {}
-        for load_idx in loadidxs:
-            load = loads[load_idx]
-            pd[load_idx] = load['pd']
-            qd[load_idx] = load['qd']
-            load_per_bus[load['load_bus']].append(load_idx)
+        for load_id in loadids:
+            load = loads[load_id]
+            pd[load_id] = load['pd']
+            qd[load_id] = load['qd']
+            load_per_bus[load['load_bus']].append(load_id)
 
         # Shunt
         gs, bs = {}, {}
-        for shunt_idx in shuntidxs:
-            shunt = shunts[shunt_idx]
-            gs[shunt_idx] = shunt['gs']
-            bs[shunt_idx] = shunt['bs']
-            shunt_per_bus[shunt['shunt_bus']].append(shunt_idx)
+        for shunt_id in shuntids:
+            shunt = shunts[shunt_id]
+            gs[shunt_id] = shunt['gs']
+            bs[shunt_id] = shunt['bs']
+            shunt_per_bus[shunt['shunt_bus']].append(shunt_id)
 
         # Bus
         vmmax, vmmin = {}, {}
         slack = []
-        for bus_idx in busidxs:
-            bus = buses[bus_idx]
-            vmmax[bus_idx] = bus['vmax']
-            vmmin[bus_idx] = bus['vmin']
+        for bus_id in busids:
+            bus = buses[bus_id]
+            vmmax[bus_id] = bus['vmax']
+            vmmin[bus_id] = bus['vmin']
             bustype = bus['bus_type']
             if bustype == 3:
-                slack.append(bus_idx)
+                slack.append(bus_id)
         
         # Branch
         rate_a = {}
         bus_from, bus_to = {}, {}
         g_from, g_to, b_from, b_to, T_R, T_I, T_m, g, b = {}, {}, {}, {}, {}, {}, {}, {}, {}
         dvamin, dvamax = {}, {}
-        for branch_idx in branchidxs:
-            branch = branches[branch_idx]
+        for branch_id in branchids:
+            branch = branches[branch_id]
             rate_a_val = branch['rate_a']
             if rate_a_val == 0.: rate_a_val + 1e12
-            rate_a[branch_idx] = rate_a_val
-            bus_from[branch_idx] = branch['f_bus']
-            bus_to[branch_idx] = branch['t_bus']
-            g_from[branch_idx] = branch['g_fr']
-            g_to[branch_idx] = branch['g_to']
-            b_from[branch_idx] = branch['b_fr']
-            b_to[branch_idx] = branch['b_to']
+            rate_a[branch_id] = rate_a_val
+            bus_from[branch_id] = branch['f_bus']
+            bus_to[branch_id] = branch['t_bus']
+            g_from[branch_id] = branch['g_fr']
+            g_to[branch_id] = branch['g_to']
+            b_from[branch_id] = branch['b_fr']
+            b_to[branch_id] = branch['b_to']
             T_m_val = branch['tap']
             shift = branch['shift']
-            T_R[branch_idx] = T_m_val * math.cos(shift)
-            T_I[branch_idx] = T_m_val * math.sin(shift)
-            T_m[branch_idx] = T_m_val
+            T_R[branch_id] = T_m_val * math.cos(shift)
+            T_I[branch_id] = T_m_val * math.sin(shift)
+            T_m[branch_id] = T_m_val
             r = branch['br_r']
             x = branch['br_x']
-            g[branch_idx] = r / (r**2 + x**2)
-            b[branch_idx] = -x / (r**2 + x**2)
-            dvamin[branch_idx] = branch['angmin']
-            dvamax[branch_idx] = branch['angmax']
-            branch_out_per_bus[branch['f_bus']].append(branch_idx) # from buses
-            branch_in_per_bus[branch['t_bus']].append(branch_idx)
+            g[branch_id] = r / (r**2 + x**2)
+            b[branch_id] = -x / (r**2 + x**2)
+            dvamin[branch_id] = branch['angmin']
+            dvamax[branch_id] = branch['angmax']
+            branch_out_per_bus[branch['f_bus']].append(branch_id) # from buses
+            branch_in_per_bus[branch['t_bus']].append(branch_id)
 
         if init_var is not None:
             pg_init = init_var['pg']
@@ -255,19 +255,19 @@ class AbstractACOPFModel(AbstractPowerBaseModel):
         else:
             pg_init = pg
             qg_init = qg
-            vm_init = { idx: 1. for idx in busidxs }
-            va_init = { idx: 0. for idx in busidxs }
-            pf_from_init = { idx: 0. for idx in branchidxs }
-            pf_to_init = { idx: 0. for idx in branchidxs }
-            qf_from_init = { idx: 0. for idx in branchidxs }
-            qf_to_init = { idx: 0. for idx in branchidxs }
+            vm_init = { id: 1. for id in busids }
+            va_init = { id: 0. for id in busids }
+            pf_from_init = { id: 0. for id in branchids }
+            pf_to_init = { id: 0. for id in branchids }
+            qf_from_init = { id: 0. for id in branchids }
+            qf_to_init = { id: 0. for id in branchids }
                 
         data = {
-            'G': {None: genidxs},
-            'B': {None: busidxs},
-            'E': {None: branchidxs},
-            'L': {None: loadidxs},
-            'S': {None: shuntidxs},
+            'G': {None: genids},
+            'B': {None: busids},
+            'E': {None: branchids},
+            'L': {None: loadids},
+            'S': {None: shuntids},
             'pg_init': pg_init,
             'qg_init': qg_init,
             'vm_init': vm_init,
@@ -303,7 +303,10 @@ class AbstractACOPFModel(AbstractPowerBaseModel):
         self.model.branch_out_per_bus_raw = branch_out_per_bus
         self.model.shunt_per_bus_raw = shunt_per_bus
         
-        instance = self.model.create_instance({None: data}) # create instance (ConcreteModel), 
+        import time
+        t0 = time.time()
+        instance = self.model.create_instance({None: data}, report_timing=verbose) # create instance (ConcreteModel), 
+        print('elapsed time for create_instance', time.time()-t0)
         instance.dual = pyo.Suffix(direction=pyo.Suffix.IMPORT_EXPORT) # define the dual assess point
         # note that self.model is not duplicated because it is desired to be AbstractModel 
         # for taking different types of problem instances consistently.

--- a/opf/core/acopf_exp.py
+++ b/opf/core/acopf_exp.py
@@ -49,30 +49,30 @@ def cnst_ohm_qf_to_exp(m, e):
                 + ((-m.g[e] * m.T_R[e] - m.b[e] * m.T_I[e])/m.T_m[e]**2) * (m.vm[m.bus_from[e]] * m.vm[m.bus_to[e]]) * pyo.sin(-m.va[m.bus_from[e]] + m.va[m.bus_to[e]])
             
 def define_sets_balance_exp(m):
-    for busidx, genlist in m.gen_per_bus_raw.items():
+    for busid, genlist in m.gen_per_bus_raw.items():
         if len(genlist) > 0:
-            for genidx in genlist:
-                m.gen_per_bus[busidx].add(genidx)
+            for genid in genlist:
+                m.gen_per_bus[busid].add(genid)
 
-    for busidx, loadlist in m.load_per_bus_raw.items():
+    for busid, loadlist in m.load_per_bus_raw.items():
         if len(loadlist) > 0:
-            for loadidx in loadlist:
-                m.load_per_bus[busidx].add(loadidx)
+            for loadid in loadlist:
+                m.load_per_bus[busid].add(loadid)
 
-    for busidx, branchlist in m.branch_in_per_bus_raw.items():
+    for busid, branchlist in m.branch_in_per_bus_raw.items():
         if len(branchlist) > 0:
-            for branchidx in branchlist:
-                m.branch_in_per_bus[busidx].add(branchidx)
+            for branchid in branchlist:
+                m.branch_in_per_bus[busid].add(branchid)
     
-    for busidx, branchlist in m.branch_out_per_bus_raw.items():
+    for busid, branchlist in m.branch_out_per_bus_raw.items():
         if len(branchlist) > 0:
-            for branchidx in branchlist:
-                m.branch_out_per_bus[busidx].add(branchidx)
+            for branchid in branchlist:
+                m.branch_out_per_bus[busid].add(branchid)
     
-    for busidx, shuntlist in m.shunt_per_bus_raw.items():
+    for busid, shuntlist in m.shunt_per_bus_raw.items():
         if len(shuntlist) > 0:
-            for shuntidx in shuntlist:
-                m.shunt_per_bus[busidx].add(shuntidx)
+            for shuntid in shuntlist:
+                m.shunt_per_bus[busid].add(shuntid)
 
 def cnst_p_balance_exp(m, b):
     return quicksum(m.pg[g] for g in m.gen_per_bus[b])\

--- a/opf/core/base.py
+++ b/opf/core/base.py
@@ -15,5 +15,5 @@ class AbstractPowerBaseModel(ABC):
     def _build_model(self) -> None: pass
 
     @abstractmethod
-    def instantiate_model(self, network:Dict[str,Any], init_var:Dict[str,Any] = None) -> pyo.ConcreteModel: pass
+    def instantiate_model(self, network:Dict[str,Any], init_var:Dict[str,Any] = None, verbose:bool = False) -> pyo.ConcreteModel: pass
 

--- a/opf/core/dcopf.py
+++ b/opf/core/dcopf.py
@@ -17,7 +17,7 @@ class AbstractDCOPFModel(AbstractPowerBaseModel):
         """ Define the (abstract) DC-OPF optimization model. 
             This is enabled without having the specific parameter values.
         """
-        print('build model...', end=' ')
+        print('build model...', end=' ', flush=True)
         self.model.B = pyo.Set() # bus indices
         self.model.G = pyo.Set() # generator indices
         self.model.E = pyo.Set() # branch indices
@@ -89,7 +89,7 @@ class AbstractDCOPFModel(AbstractPowerBaseModel):
         # IIII.   Objective
         # ====================
         self.model.obj_cost = pyo.Objective(sense=pyo.minimize, rule=obj_cost_exp)
-        print('end')
+        print('end', flush=True)
 
 
     def instantiate_model(self, network:Dict[str,Any], init_var:Dict[str,Any] = None, verbose:bool = False) -> pyo.ConcreteModel:

--- a/opf/core/dcopf_exp.py
+++ b/opf/core/dcopf_exp.py
@@ -17,28 +17,28 @@ def cnst_slack_va_exp(m, s):
     return m.va[s] == 0.
 
 def cnst_pf_exp(m, e):
-    return m.pf[e] - quicksum(m.ang2pf[e,b]*m.va[b] for b in m.B) == 0.
+    return m.pf[e] - quicksum(m.ang2pf[e,b]*m.va[b] for b in m.bus_per_branch[e]) == 0.
 
 def define_sets_balance_exp(m):
-    for busidx, genlist in m.gen_per_bus_raw.items():
-        if len(genlist) > 0:
-            for genidx in genlist:
-                m.gen_per_bus[busidx].add(genidx)
+    for busid, genlist in m.gen_per_bus_raw.items():
+        for genid in genlist:
+            m.gen_per_bus[busid].add(genid)
 
-    for busidx, loadlist in m.load_per_bus_raw.items():
-        if len(loadlist) > 0:
-            for loadidx in loadlist:
-                m.load_per_bus[busidx].add(loadidx)
+    for busid, loadlist in m.load_per_bus_raw.items():
+        for loadid in loadlist:
+            m.load_per_bus[busid].add(loadid)
 
-    for busidx, branchlist in m.branch_in_per_bus_raw.items():
-        if len(branchlist) > 0:
-            for branchidx in branchlist:
-                m.branch_in_per_bus[busidx].add(branchidx)
+    for busid, branchlist in m.branch_in_per_bus_raw.items():
+        for branchid in branchlist:
+            m.branch_in_per_bus[busid].add(branchid)
     
-    for busidx, branchlist in m.branch_out_per_bus_raw.items():
-        if len(branchlist) > 0:
-            for branchidx in branchlist:
-                m.branch_out_per_bus[busidx].add(branchidx)
+    for busid, branchlist in m.branch_out_per_bus_raw.items():
+        for branchid in branchlist:
+            m.branch_out_per_bus[busid].add(branchid)
+
+    for branchid, buslist in m.bus_per_branch_raw.items():
+        for busid in buslist:
+            m.bus_per_branch[branchid].add(busid)
 
 def cnst_power_bal_exp(m, b):
     return quicksum(m.pf[e] for e in m.branch_out_per_bus[b]) - quicksum(m.pf[e] for e in m.branch_in_per_bus[b])\

--- a/opf/core/dcopf_ptdf.py
+++ b/opf/core/dcopf_ptdf.py
@@ -73,7 +73,8 @@ class AbstractDCOPFModelPTDF(AbstractPowerBaseModel):
         self.model.obj_cost = pyo.Objective(sense=pyo.minimize, rule=obj_cost_exp)
         print('end')
 
-    def instantiate_model(self, network:Dict[str,Any], init_var:Dict[str,Any] = None) -> pyo.ConcreteModel:
+
+    def instantiate_model(self, network:Dict[str,Any], init_var:Dict[str,Any] = None, verbose:bool = False) -> pyo.ConcreteModel:
         print('instantiate model...', end=' ', flush=True)
         gens = network['gen']
         buses = network['bus']
@@ -164,8 +165,7 @@ class AbstractDCOPFModelPTDF(AbstractPowerBaseModel):
             'ptdf_l': ptdf_l
         }
 
-        # print('create_instance', flush=True)
-        instance = self.model.create_instance({None: data}) # create instance (ConcreteModel), 
+        instance = self.model.create_instance({None: data}, report_timing=verbose) # create instance (ConcreteModel)
         instance.dual = pyo.Suffix(direction=pyo.Suffix.IMPORT_EXPORT) # define the dual assess point
         print('end')
         return instance

--- a/opf/core/dcopf_ptdf.py
+++ b/opf/core/dcopf_ptdf.py
@@ -18,7 +18,7 @@ class AbstractDCOPFModelPTDF(AbstractPowerBaseModel):
         """ Define the (abstract) DC-OPF optimization model. 
             This is enabled without having the specific parameter values.
         """
-        print('build model...', end=' ')
+        print('build model...', end=' ', flush=True)
         self.model.B = pyo.Set() # bus indices
         self.model.G = pyo.Set() # generator indices
         self.model.E = pyo.Set() # branch indices
@@ -72,7 +72,7 @@ class AbstractDCOPFModelPTDF(AbstractPowerBaseModel):
         # IIII.   Objective
         # ====================
         self.model.obj_cost = pyo.Objective(sense=pyo.minimize, rule=obj_cost_exp)
-        print('end')
+        print('end', flush=True)
 
 
     def instantiate_model(self, network:Dict[str,Any], init_var:Dict[str,Any] = None, verbose:bool = False) -> pyo.ConcreteModel:
@@ -165,5 +165,5 @@ class AbstractDCOPFModelPTDF(AbstractPowerBaseModel):
         
         instance = self.model.create_instance({None: data}, report_timing=verbose) # create instance (ConcreteModel)
         instance.dual = pyo.Suffix(direction=pyo.Suffix.IMPORT_EXPORT) # define the dual assess point
-        print('end')
+        print('end', flush=True)
         return instance

--- a/opf/core/dcopf_ptdf.py
+++ b/opf/core/dcopf_ptdf.py
@@ -1,0 +1,171 @@
+from typing import Any, Dict
+import pyomo.environ as pyo
+import numpy as np
+import math
+
+from .base import AbstractPowerBaseModel
+from .dcopf_exp import *
+from .dcopf_ptdf_exp import *
+from .utils import compute_ptdf
+
+class AbstractDCOPFModelPTDF(AbstractPowerBaseModel):
+    """ Abstract DC-OPF using PTDF (power transfer distribution factor) optimization model class.  
+    """
+    def __init__(self, model_type):
+        super().__init__(model_type)
+
+    def _build_model(self) -> None:
+        """ Define the (abstract) DC-OPF optimization model. 
+            This is enabled without having the specific parameter values.
+        """
+        print('build model...', end=' ')
+        self.model.B = pyo.Set() # bus indices
+        self.model.G = pyo.Set() # generator indices
+        self.model.E = pyo.Set() # branch indices
+        self.model.L = pyo.Set() # load indices
+        self.model.slack = pyo.Set() # the slack buses
+        self.model.ncost = pyo.Set() # the number of costs
+
+        # # ====================
+        # # I.    Parameters
+        # # ====================
+        self.model.pg_init = pyo.Param(self.model.G, within=pyo.Reals, mutable=True)
+        self.model.pf_init = pyo.Param(self.model.E, within=pyo.Reals, mutable=True)
+        self.model.pgmin = pyo.Param(self.model.G, within=pyo.Reals, mutable=True)
+        self.model.pgmax = pyo.Param(self.model.G, within=pyo.Reals, mutable=True)
+        self.model.pd = pyo.Param(self.model.L, within=pyo.Reals, mutable=True)
+        self.model.rate_a = pyo.Param(self.model.E, within=pyo.NonNegativeReals, mutable=True)
+        self.model.cost = pyo.Param(self.model.G, self.model.ncost, within=pyo.Reals, mutable=True)
+        self.model.ptdf_g = pyo.Param(self.model.E, self.model.G, within=pyo.Reals, mutable=True)
+        self.model.ptdf_l = pyo.Param(self.model.E, self.model.L, within=pyo.Reals, mutable=True)
+
+        # # ====================
+        # # II.    Variables
+        # # ====================
+        self.model.pg = pyo.Var(self.model.G, initialize=self.model.pg_init, within=pyo.Reals) # active generation (injection), continuous
+        self.model.pf = pyo.Var(self.model.E, initialize=self.model.pf_init, within=pyo.Reals) # active flow (at each branch)
+
+        # ====================
+        # III.   Constraints
+        # ====================
+
+        # ====================
+        # III.a     Bounds
+        # ====================
+        self.model.cnst_pg_bound_min = pyo.Constraint(self.model.G, rule=cnst_pg_bound_min_exp)
+        self.model.cnst_pg_bound_max = pyo.Constraint(self.model.G, rule=cnst_pg_bound_max_exp)
+        self.model.cnst_pf_bound_min = pyo.Constraint(self.model.E, rule=cnst_pf_bound_min_exp)
+        self.model.cnst_pf_bound_max = pyo.Constraint(self.model.E, rule=cnst_pf_bound_max_exp)
+
+        # ====================
+        # III.b Define Flow
+        # ====================
+        self.model.cnst_pf = pyo.Constraint(self.model.E, rule=cnst_pf_ptdf_exp)
+
+        # ====================
+        # III.c Power Balance
+        # ====================
+        self.model.cnst_power_bal = pyo.Constraint(rule=cnst_power_bal_ptdf_exp)
+
+        # ====================
+        # IIII.   Objective
+        # ====================
+        self.model.obj_cost = pyo.Objective(sense=pyo.minimize, rule=obj_cost_exp)
+        print('end')
+
+    def instantiate_model(self, network:Dict[str,Any], init_var:Dict[str,Any] = None) -> pyo.ConcreteModel:
+        print('instantiate model...', end=' ', flush=True)
+        gens = network['gen']
+        buses = network['bus']
+        branches = network['branch']
+        loads = network['load']
+
+        busids = sorted(list(buses.keys())) # sort this for consistency between the pyomo vector and the input matpower 
+        loadids = sorted(list(loads.keys()))
+
+        branchids_all = sorted(list(branches.keys()))
+        branchids = [branch_id for branch_id in branchids_all if branches[branch_id]['br_status']>0] # factor out not working branches
+        genids_all = sorted(list(gens.keys())) 
+        genids = [gen_id for gen_id in genids_all if gens[gen_id]['gen_status']>0] # factor out not working generators
+
+        ncost = 3 # all PGLib input files have three cost coefficients
+
+        # Generator
+        pgmax, pgmin, pg, qg, cost = {}, {}, {}, {}, {}
+        for gen_id in genids:
+            gen = gens[gen_id]
+            pgmax[gen_id] = gen['pmax']
+            pgmin[gen_id] = gen['pmin']
+            pg[gen_id] = gen['pg']
+            qg[gen_id] = gen['qg']
+            cost_raw = gen['cost']
+            for i in range(ncost):
+                cost[(gen_id,i)] = cost_raw[i]
+
+        # Load 
+        pd = {}
+        for load_id in loadids:
+            load = loads[load_id]
+            pd[load_id] = load['pd']
+
+        # Bus
+        slack = []
+        for bus_id in busids:
+            if buses[bus_id]['bus_type'] == 3:
+                slack.append(bus_id)
+
+        # Branch
+        rate_a = {}
+        ang2pf = {}
+        for branch_id in branchids:
+            branch = branches[branch_id]
+            rate_a_val = branch['rate_a']
+            if rate_a_val == 0.: rate_a_val + 1e12
+            rate_a[branch_id] = rate_a_val
+
+        
+        if init_var is not None:
+            pg_init = init_var['pg']
+            pf_init = init_var['pf']
+        else:
+            pg_init = pg
+            pf_init = { id: 0. for id in branchids }
+
+        ptdf_g_raw, ptdf_l_raw = compute_ptdf(network)
+
+        # self.model.ptdf_g = {}
+        # self.model.ptdf_l = {}
+        # for i, branchid in enumerate(branchids):
+        #     self.model.ptdf_g[branchid] = ptdf_g[i,:]
+        #     self.model.ptdf_l[branchid] = ptdf_l[i,:]
+
+        ptdf_g, ptdf_l = {}, {}
+        for i, branchid in enumerate(branchids):
+            for j, genid in enumerate(genids):
+                ptdf_g[(branchid,genid)] = ptdf_g_raw[i,j]
+            for j, loadid in enumerate(loadids):
+                ptdf_l[(branchid,loadid)] = ptdf_l_raw[i,j]
+
+        data = {
+            'G': {None: genids},
+            'B': {None: busids},
+            'E': {None: branchids},
+            'L': {None: loadids},
+            'slack': {None: slack},
+            'pg_init': pg_init,
+            'pf_init': pf_init,
+            'ncost': {None: np.arange(ncost)},
+            'pd': pd,
+            'pgmax': pgmax,
+            'pgmin': pgmin,
+            'cost': cost,
+            'rate_a': rate_a,
+            'ptdf_g': ptdf_g,
+            'ptdf_l': ptdf_l
+        }
+
+        # print('create_instance', flush=True)
+        instance = self.model.create_instance({None: data}) # create instance (ConcreteModel), 
+        instance.dual = pyo.Suffix(direction=pyo.Suffix.IMPORT_EXPORT) # define the dual assess point
+        print('end')
+        return instance

--- a/opf/core/dcopf_ptdf_exp.py
+++ b/opf/core/dcopf_ptdf_exp.py
@@ -1,11 +1,10 @@
 import pyomo.environ as pyo
 from pyomo.core.util import quicksum
-
+from pyomo.core.expr.numeric_expr import LinearExpression
 
 def cnst_pf_ptdf_exp(m, e):
-    load_injection = [m.ptdf_l[e,l]*m.pd[l] for l in m.L]
-    gen_injection = [m.ptdf_g[e,g]*m.pg[g] for g in m.G]
-    return m.pf[e] == quicksum(load_injection) - quicksum(gen_injection) 
+    m.gen_injection = LinearExpression(constant=0, linear_coefs=m.ptdf_g[e], linear_vars=[m.pg[g] for g in m.G])
+    return m.pf[e] == m.load_injection[e] - m.gen_injection
     
 
 def cnst_power_bal_ptdf_exp(m):

--- a/opf/core/dcopf_ptdf_exp.py
+++ b/opf/core/dcopf_ptdf_exp.py
@@ -1,0 +1,13 @@
+import pyomo.environ as pyo
+from pyomo.core.util import quicksum
+
+
+def cnst_pf_ptdf_exp(m, e):
+    load_injection = [m.ptdf_l[e,l]*m.pd[l] for l in m.L]
+    gen_injection = [m.ptdf_g[e,g]*m.pg[g] for g in m.G]
+    return m.pf[e] == quicksum(load_injection) - quicksum(gen_injection) 
+    
+
+def cnst_power_bal_ptdf_exp(m):
+    return quicksum(m.pd[l] for l in m.L) == quicksum(m.pg[g] for g in m.G)
+    

--- a/opf/core/func.py
+++ b/opf/core/func.py
@@ -1,5 +1,6 @@
 from .acopf import AbstractACOPFModel
 from .dcopf import AbstractDCOPFModel
+from .dcopf_ptdf import AbstractDCOPFModelPTDF
 from .base import AbstractPowerBaseModel
 
 
@@ -17,6 +18,8 @@ def build_model(model_type:str) -> AbstractPowerBaseModel:
         model = AbstractACOPFModel(model_type)
     elif model_type == 'dcopf':
         model = AbstractDCOPFModel(model_type)
+    elif model_type == 'dcopf-ptdf':
+        model = AbstractDCOPFModelPTDF(model_type) 
     else:
         assert False
 

--- a/opf/core/utils.py
+++ b/opf/core/utils.py
@@ -1,0 +1,149 @@
+from typing import Dict, Any, Tuple
+import numpy as np
+from scipy.sparse import coo_array
+from scipy.linalg import solve_triangular, ldl    
+
+def compute_ptdf(network:Dict[str,Any]) ->  Tuple[Dict[str,Any], Dict[str,Any]]:
+    S_br = compute_branch_susceptance_matrix(network).toarray() # ExB
+    S_b = compute_bus_susceptance_matrix(network).toarray() # BxB
+    I_g = compute_generator_incidence_matrix(network).toarray() # BxG
+    I_l = compute_load_incidence_matrix(network).toarray() # BxL
+    
+    buses = network['bus']
+    busids = sorted(list(buses.keys()))
+    slack = [ buses[busid]['index'] for busid in busids if buses[busid]['bus_type'] == 3]
+    if len(slack) != 1:
+        raise ValueError(f'The number of slack buses should be 1. But it is now {len(slack)}.')
+
+    return _compute_ptdf(S_br, S_b, I_g, I_l, slack)
+
+
+def _compute_ptdf(S_br, S_b, I_g, I_l, slack):
+    # for the slack bus, zeroing the bus susceptance entries.
+    S_b[:,slack[0]] = 0.
+    S_b[slack[0],:] = 0.
+    S_b[slack[0],slack[0]] = 1.
+
+    # LDLT decomposition
+    L, D, perm = ldl(S_b, lower=True) 
+    L = L[perm,:]
+    D = np.diag(D)[perm]
+    D_inv = np.diag(1./D)
+
+    # solve for I_g
+    y_g = solve_triangular(L, I_g, lower=True)
+    y_g = D_inv @ y_g
+    x_g = solve_triangular(L.T, y_g, lower=False)
+
+    # solve for I_l
+    y_l = solve_triangular(L, I_l, lower=True)
+    y_l = D_inv @ y_l
+    x_l = solve_triangular(L.T, y_l, lower=False)
+
+    x_g[slack[0],:] = 0.
+    x_l[slack[0],:] = 0.
+
+    # compute ptdf for gen and load
+    ptdf_g = S_br @ x_g
+    ptdf_l = S_br @ x_l
+    return ptdf_g, ptdf_l
+
+
+
+def compute_branch_susceptance_matrix(network):
+    branches = network['branch']
+    branchids_all = sorted(list(branches.keys()))
+    branchids = [branch_id for branch_id in branchids_all if branches[branch_id]['br_status']>0] # factor out not working branches
+    buses = network['bus']
+
+    E = len(branchids)
+    B = len(buses)
+
+    row, col, data = [], [], []
+    for bi, branch_id in enumerate(branchids):
+        branch = branches[branch_id]
+        f_bus_id = branch['f_bus']
+        t_bus_id = branch['t_bus']
+        f_bus_idx = buses[f_bus_id]['index']
+        t_bus_idx = buses[t_bus_id]['index']
+        r = branch['br_r']
+        x = branch['br_x']
+        b = -x / (r**2 + x**2) # susceptance
+        row.append(bi); col.append(f_bus_idx); data.append(b)
+        row.append(bi); col.append(t_bus_idx); data.append(-b)
+    
+    row = np.asarray(row)
+    col = np.asarray(col)
+    data = np.asarray(data)
+    return coo_array((data,(row,col)), shape=(E, B))
+
+
+def compute_bus_susceptance_matrix(network):
+    branches = network['branch']
+    branchids_all = sorted(list(branches.keys()))
+    branchids = [branch_id for branch_id in branchids_all if branches[branch_id]['br_status']>0] # factor out not working branches
+    buses = network['bus']
+
+    B = len(buses)
+
+    row, col, data = [], [], []
+    for bi, branch_id in enumerate(branchids):
+        branch = branches[branch_id]
+        f_bus_id = branch['f_bus']
+        t_bus_id = branch['t_bus']
+        f_bus_idx = buses[f_bus_id]['index']
+        t_bus_idx = buses[t_bus_id]['index']
+        r = branch['br_r']
+        x = branch['br_x']
+        b = -x / (r**2 + x**2) # susceptance
+        row.append(f_bus_idx); col.append(t_bus_idx); data.append(-b)
+        row.append(t_bus_idx); col.append(f_bus_idx); data.append(-b)
+        row.append(f_bus_idx); col.append(f_bus_idx); data.append(b)
+        row.append(t_bus_idx); col.append(t_bus_idx); data.append(b)
+
+    row = np.asarray(row)
+    col = np.asarray(col)
+    data = np.asarray(data)
+    return coo_array((data,(row,col)), shape=(B, B))
+
+
+def compute_generator_incidence_matrix(network):
+    gens = network['gen']
+    buses = network['bus']
+    genids_all = sorted(list(gens.keys()))
+    genids = [gen_id for gen_id in genids_all if gens[gen_id]['gen_status']>0] # factor out not working generators
+
+    G = len(gens)
+    B = len(buses)
+
+    row, col = [], []
+    for i, genid in enumerate(genids):
+        gen = gens[genid]
+        gen_bus_id = gen['gen_bus']
+        row.append(buses[gen_bus_id]['index'])
+        col.append(gen['index'])
+
+    row = np.asarray(row)
+    col = np.asarray(col)
+    data = np.ones(row.shape)
+    return coo_array((data,(row,col)), shape=(B,G))
+
+
+def compute_load_incidence_matrix(network):
+    loads = network['load']
+    loadids = sorted(list(loads.keys()))
+    buses = network['bus']
+
+    L = len(loads)
+    B = len(buses)
+
+    row, col = [], []
+    for i, loadid in enumerate(loadids):
+        busid = loads[loadid]['load_bus']
+        row.append(buses[busid]['index'])
+        col.append(loads[loadid]['index'])
+
+    row = np.asarray(row)
+    col = np.asarray(col)
+    data = np.ones(row.shape)
+    return coo_array((data,(row,col)), shape=(B,L))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ typing-extensions
 
 pyomo>=6.5.0
 numpy>=1.22.3
+scipy>=1.10.1

--- a/tests/test_dcopf_ptdf_solve.py
+++ b/tests/test_dcopf_ptdf_solve.py
@@ -3,11 +3,11 @@ import opf
 from pathlib import Path
 import pyomo.environ as pyo
 
-class DCOPFSolveTest_case5(unittest.TestCase):
-    def test_solve5(self):
+class DCOPFPTDFSolveTest(unittest.TestCase):
+    def test_solve_case5(self):
         matpower_fn = Path("./data/pglib_opf_case5_pjm.m")
-        model = opf.build_model('dcopf')
-        self.assertEqual(model.model_type, 'dcopf')
+        model = opf.build_model('dcopf-ptdf')
+        self.assertEqual(model.model_type, 'dcopf-ptdf')
         network = opf.parse_file(matpower_fn)
         instance = model.instantiate_model(network)
         solver = pyo.SolverFactory("ipopt")
@@ -23,15 +23,8 @@ class DCOPFSolveTest_case5(unittest.TestCase):
         self.assertAlmostEqual(pyo.value(instance.pg[4]), 7.656316434159741e-09)
         self.assertAlmostEqual(pyo.value(instance.pg[5]), 4.6650515988209955)
 
-        self.assertAlmostEqual(pyo.value(instance.va[1]), -0.05735150733969868)
-        self.assertAlmostEqual(pyo.value(instance.va[2]), 0.01352060911369567)
-        self.assertAlmostEqual(pyo.value(instance.va[3]), 0.008035714369804532)
-        self.assertAlmostEqual(pyo.value(instance.va[4]), 0.0)
-        self.assertAlmostEqual(pyo.value(instance.va[5]), -0.07199280071944555)
 
-
-class DCOPFSolveTest_case14(unittest.TestCase):
-    def test_solve14(self):
+    def test_solve_case14(self):
         matpower_fn = Path("./data/pglib_opf_case14_ieee.m")
         model = opf.build_model('dcopf')
         self.assertEqual(model.model_type, 'dcopf')
@@ -45,12 +38,4 @@ class DCOPFSolveTest_case14(unittest.TestCase):
         self.assertAlmostEqual(pyo.value(instance.obj_cost), 2051.5262699779273)
         self.assertAlmostEqual(pyo.value(instance.pg[1]), 2.5899999800011604)
         self.assertAlmostEqual(pyo.value(instance.pg[2]), -9.962008701445461e-09)
-        self.assertAlmostEqual(pyo.value(instance.va[1]), 0.0)
-        self.assertAlmostEqual(pyo.value(instance.va[2]), 0.11768346281509813)
-        self.assertAlmostEqual(pyo.value(instance.pf[1]), 1.7962128752942261)
-        self.assertAlmostEqual(pyo.value(instance.pf[2]), 0.7937871047069344)
 
-        
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/test_ptdf.py
+++ b/tests/test_ptdf.py
@@ -1,0 +1,34 @@
+import unittest
+import opf
+from pathlib import Path
+import pyomo.environ as pyo
+import numpy as np
+
+
+class PTDFTest(unittest.TestCase):
+    def test_ptdf(self):
+        matpower_fn = Path("./data/pglib_opf_case5_pjm.m")
+        network = opf.parse_file(matpower_fn)
+        ptdf_g, ptdf_l = opf.compute_ptdf(network)
+        
+        self.assertEqual(ptdf_g.shape, (6,5))
+        self.assertEqual(ptdf_l.shape, (6,3))
+        ptdf_g_true = np.asarray(
+         [[ 0.19391661,  0.19391661, -0.34898946,  0.,   0.15953804],
+          [ 0.43758813,  0.43758813,  0.18945142,  0.,   0.36001018],
+          [ 0.36849527,  0.36849527,  0.15953804,  0.,  -0.51954822],
+          [ 0.19391661,  0.19391661, -0.34898946,  0.,   0.15953804],
+          [ 0.19391661,  0.19391661,  0.65101054,  0.,   0.15953804],
+          [-0.36849527, -0.36849527, -0.15953804,  0.,  -0.48045178]]
+        )
+        np.testing.assert_almost_equal(ptdf_g, ptdf_g_true)
+
+        ptdf_l_true = np.asarray(
+            [[-0.47589472, -0.34898946,  0. ],
+             [ 0.25834285,  0.18945142,  0. ],
+             [ 0.21755187,  0.15953804,  0. ],
+             [ 0.52410528, -0.34898946,  0. ],
+             [ 0.52410528,  0.65101054,  0. ],
+             [-0.21755187, -0.15953804,  0. ]]
+        )
+        np.testing.assert_almost_equal(ptdf_l, ptdf_l_true)


### PR DESCRIPTION
mainly to resolve #9 #10 
- PTDF based DC-OPF formulation is established
- Also, `instantiate_model` for `dcopf` and `dcopf-ptdf` was too slow, so used `LinearExpression` and sparse index set to speed-up the instantiating the `ConcreteModel`.
- parsed PGLib now has the key of `id`. Previously it was `index`. This is mainly due to easier indexing for constructing PTDF matrix
