### PR TITLE
line contingency for SC-DC-OPF

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ pip install opf
     ```python
     model = opf.build_model('acopf')
     ```
-    - AC-OPF with a polar bus voltage variables.
+    - AC-OPF with a polar bus voltage variable representations.
     - The detailed formulation can be found in [PGLib](https://github.com/power-grid-lib/pglib-opf).
-    - **PyOPF** takes the the input files in PGLib, which is basically based on MATPOWER format.
-    - Uses various solvers that are supported in Pyomo including IPOPT to solve the problem instance.
+    - `PyOPF` takes the the input files from PGLib, which is basically based on MATPOWER format.
+    - Uses various solvers supported in Pyomo including IPOPT and Gurobi to solve problem instances.
 
 2. :o: DC-OPF (DC Optimal Power Flow)
     ```python
@@ -49,7 +49,7 @@ pip install opf
     -  To be added
 
 ## Warmstarting
-* **PyOPF** fully supports primal and dual warmstarting. Documentation is to be added.
+* `PyOPF` fully supports primal and dual warmstarting for IPOPT. Documentation is to be added.
     ```python
     model.setup_warmstart(warmstart_solution_dict) 
     ```
@@ -62,17 +62,17 @@ pip install opf
     conda install -c conda-forge ipopt
     ```
 
-- Running the following example AC-OPF problem
+- Running the following AC-OPF problem
     ```python
     import opf
 
     # build abstract model for AC-OPF
     model = opf.build_model('acopf')
 
-    # load pglib based model file
+    # load pglib input model file
     network = opf.parse_file("./data/pglib_opf_case5_pjm.m")
 
-    # create the concrete model
+    # create the model instance (concrete model)
     model.instantiate(network)
 
     # solve the problem

--- a/opf/core/scdcopf.py
+++ b/opf/core/scdcopf.py
@@ -249,18 +249,10 @@ class SCDCOPFModel(SCOPFModel):
 
         if extract_contingency:
             pg_kg_sol = {}
-            pg_ke_sol = {}
-
             for g in self.instance.G:
                 for k in self.instance.K_g:
                     key = f"{g},{k}"
                     pg_kg_sol[key] = self.instance.pg_kg[g,k].value
             results['sol']['pg_kg'] = pg_kg_sol
-
-            for g in self.instance.G:
-                for k in self.instance.K_e:
-                    key = f"{g},{k}"
-                    pg_ke_sol[key] = self.instance.pg_ke[g,k].value
-            results['sol']['pg_ke'] = pg_ke_sol
 
         return None

--- a/opf/core/scdcopf.py
+++ b/opf/core/scdcopf.py
@@ -55,12 +55,9 @@ class SCDCOPFModel(SCOPFModel):
         # # ====================
         self.model.pg = pyo.Var(self.model.G, initialize=self.model.pg_init, bounds=pg_bound_exp, within=pyo.Reals) # active generation (injection), continuous
         self.model.pg_kg = pyo.Var(self.model.G, self.model.K_g, bounds = pg_kg_bound_exp, within=pyo.Reals) # active generation when generator contingency occurs
-        self.model.pg_ke = pyo.Var(self.model.G, self.model.K_e, bounds = pg_ke_bound_exp, within=pyo.Reals) # active generation when line contingency occurs
-        self.model.n_kg = pyo.Var(self.model.K_g, bounds = (0.,1.), within=pyo.Reals) # global extent of generation increase when generator contingency occurs
-        self.model.n_ke = pyo.Var(self.model.K_e, bounds = (0.,1.), within=pyo.Reals) # global extent of generation increase when line contingency occurs
-        
+
+        self.model.n_kg = pyo.Var(self.model.K_g, bounds = (0.,1.), within=pyo.Reals) # global extent of generation increase when generator contingency occurs        
         self.model.rho_kg = pyo.Var(self.model.G, self.model.K_g, bounds = (0.,None), within=pyo.Reals) # downward deviation of pg from linear response
-        self.model.rho_ke = pyo.Var(self.model.G, self.model.K_e, bounds = (0.,None), within=pyo.Reals) # downward deviation of pg from linear response
         
         self.model.pf = pyo.Var(self.model.E, bounds=pf_bound_exp, within=pyo.Reals) # power flow for base case # it is neccesary to define power flow for line contingency
 
@@ -76,27 +73,20 @@ class SCDCOPFModel(SCOPFModel):
         # ====================
         # III.b Power Flow Contingency
         # ====================
-        self.model.cnst_pf_kg = pyo.Constraint(self.model.E, self.model.K_g, rule=cnst_pf_kg_exp) # generator contingency
-        self.model.cnst_pf_ke = pyo.Constraint(self.model.E, self.model.K_e, rule=cnst_pf_ke_exp) # line contingency
+        self.model.cnst_pf_kg = pyo.Constraint(self.model.E, self.model.K_g, rule=cnst_pf_kg_exp) # generator contingency -- based on PTDF and primary response
+        self.model.cnst_pf_ke = pyo.Constraint(self.model.E, self.model.K_e, rule=cnst_pf_ke_exp) # line contingency -- based on LODF
 
         # ====================
         # III.c Power Balance
         # ====================
         self.model.cnst_power_bal = pyo.Constraint(rule=cnst_power_bal_ptdf_exp) # base case
         self.model.cnst_power_bal_kg = pyo.Constraint(self.model.K_g, rule=cnst_power_bal_ptdf_kg_exp) # generator contingency
-        self.model.cnst_power_bal_ke = pyo.Constraint(self.model.K_e, rule=cnst_power_bal_ptdf_ke_exp) # line contingency
-
+        
         # ====================
         # III.c Primary Response for Generator Contingency
         # ====================
         self.model.cnst_pr_kg1 = pyo.Constraint(self.model.G, self.model.K_g, rule=cnst_pr_kg1_exp)
         self.model.cnst_pr_kg2 = pyo.Constraint(self.model.G, self.model.K_g, rule=cnst_pr_kg2_exp)
-
-        # ====================
-        # III.d Primary Response for Line Contingency
-        # ====================
-        self.model.cnst_pr_ke1 = pyo.Constraint(self.model.G, self.model.K_e, rule=cnst_pr_ke1_exp)
-        self.model.cnst_pr_ke2 = pyo.Constraint(self.model.G, self.model.K_e, rule=cnst_pr_ke2_exp)
 
         # ====================
         # IIII.   Objective

--- a/opf/core/scdcopf_exp.py
+++ b/opf/core/scdcopf_exp.py
@@ -8,9 +8,6 @@ def pg_kg_bound_exp(m, g, k):
     else:
         return (m.pgmin[g], m.pgmax[g])
 
-def pg_ke_bound_exp(m, g, k):
-    return (m.pgmin[g], m.pgmax[g])
-
 def cnst_pf_repr_exp(m, e):
     m.gen_injection = LinearExpression(constant=0, linear_coefs=m.ptdf_g[e], linear_vars=[m.pg[g] for g in m.G])
     return m.pf[e] == m.gen_injection - m.load_injection[e]
@@ -40,14 +37,5 @@ def cnst_pr_kg2_exp(m, g, k):
     else:
         return m.rho_kg[g,k] * (m.pgmax[g]-m.pg_kg[g,k]) <= m.eps * m.pgcapa[g]
 
-def cnst_pr_ke1_exp(m, g, k):
-    return m.pg_ke[g,k] + m.rho_ke[g,k] == m.pg[g] + m.n_ke[k]*m.gamma[g]*m.pgcapa[g]
-
-def cnst_pr_ke2_exp(m, g, k):
-    return m.rho_ke[g,k] * (m.pgmax[g]-m.pg_ke[g,k]) <= m.eps * m.pgcapa[g]
-
 def cnst_power_bal_ptdf_kg_exp(m, k):
     return quicksum(m.pd[l] for l in m.L) == quicksum(m.pg_kg[g,k] for g in m.G)
-
-def cnst_power_bal_ptdf_ke_exp(m, k):
-    return quicksum(m.pd[l] for l in m.L) == quicksum(m.pg_ke[g,k] for g in m.G)


### PR DESCRIPTION
line contingency should be defined just using LODF, and primary response is not necessary 
because there is no frequency drop (or increase) that affects generation perturbation.
With DC, it is assumed that power loss does not exist, as long as the load demand is consistent, the generation injection should be maintained as in base case, and only consider the flow limit (thermal limit) for line contingency, which can be defined by LODF.

In CCGA, binary search for the variables associated with primary response is not necessary for line contingency. Instead, we iteratively collect flow limit constraints and add into the master problem which is by LODF again.